### PR TITLE
Remove unnecessary POI name formatting for Khaas medical POIs in Map component

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -220,9 +220,6 @@ export default function Map({ userLocation, onZoneClick }: MapProps) {
   const createPOIIcon = (poi: POI) => {
     const category = POI_CATEGORIES[poi.category];
     const showLabel = poi.category === "khaas"; // Show labels for Khaas medical POIs
-    const poiName = poi.name.includes("Mahal us Shifa Khaas")
-      ? poi.name.split(" - ")[0] // Show just the facility name (before the dash)
-      : poi.name;
 
     return new L.DivIcon({
       html: `


### PR DESCRIPTION
Eliminate the formatting for Khaas medical POIs to simplify the display of their names in the Map component.